### PR TITLE
Fixes TypeError exception in request for addResultsForCases method.

### DIFF
--- a/src/testrail.coffee
+++ b/src/testrail.coffee
@@ -330,7 +330,7 @@ class TestRail
         this.addExtraCommand("add_result_for_case/", run_id, ("/" + case_id),  JSON.stringify(json), callback)
 
     addResultsForCases: (run_id, results, callback) ->
-        this.addExtraCommand("add_results_for_cases/", run_id,  JSON.stringify(results), callback)
+        this.addExtraCommand("add_results_for_cases/", run_id, "",  JSON.stringify(results), callback)
 
     #-------- RESULT FIELDS ---------------------
 


### PR DESCRIPTION
Was getting a the following exception when attempting to run `TestRail.addResultsForCases`:

```error
TypeError: must start with number, buffer, array or string
    at new Buffer (buffer.js:67:11)
    at Request.self._buildRequest (/path/to/project/node_modules/node-testrail/node_modules/request/request.js:336:23)
```

Just a simple argument order/number issue.