### PR TITLE
Remove suite_id from updateRun function.

### DIFF
--- a/src/testrail.coffee
+++ b/src/testrail.coffee
@@ -356,7 +356,6 @@ class TestRail
 
     updateRun: (runID,name,description, callback) ->
         json = {}
-        json.suite_id = suite_id
         json.name = name
         json.description = description
         this.addCommand("update_run/", runID, JSON.stringify(json) , callback)


### PR DESCRIPTION
I removed suite_id from the updateRun function as it was not defined.
The updateRun function was throwing an error:

`
ReferenceError: suite_id is not defined
    at TestRail.updateRun (node_modules/node-testrail/lib/testrail.js:362:23)
`

I have tested the change out and the function now works.
The TestRail api does not require the suite_id parameter for the update_run method.