### PR TITLE
Proposed version increment to publish new version to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Stewart Taylor <stewart@taylore.net> (http://taylore.net",
   "name": "node-testrail",
   "description": "An API wrapper for TestRail",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Stewart-Taylor/Node-TestRail.git"
@@ -20,5 +20,6 @@
   "devDependencies": {
     "coffee-script": ">= 1.3"
   },
-  "keywords": ["testrail", "api", "wrapper"]
+  "keywords": ["testrail", "api", "wrapper"],
+  "license": "MIT"
 }


### PR DESCRIPTION
I noticed that the new version has not been republished to npm.
I am not 100% sure how all of it works, but from what I gather it involves incrementing the version number and then republishing the package to npm?

Could you please republish it with the bugfix from the last pull request?

I also noticed that you state in the readme that the license is MIT, so I added it to the package.json as well, so that it is easier for people to find in npm.

Cheers